### PR TITLE
Add labels prop for localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ export default App;
 | defaultActiveTab      |  `string`  |         `undefined`         | Default value for active tab when initializing the component, takes two values: `solid` or `gradient` |
 | onChangeTabs          | `function` |           `null`            | Default onChange function detect when tabs change and return one of the values: `solid` or `gradient` |
 | onChange              | `function` |           `null`            | Default onChange function returns string value in the given format                                    |
+| labels                |  `object`  |         `undefined`         | Override UI text labels for localization. See [Localization](#localization)                           |
 
 When passing a value for a gradient, you must specify the position of all colors. Otherwise the component will throw an exception.
 For example:
@@ -121,6 +122,32 @@ circle at right bottom
 'linear-gradient(90deg, rgb(120, 115, 245) 0%, rgb(236, 119, 171) 100%)',
 'linear-gradient(45deg, #2e266f 0.00%, #9664dd38 100.00%)',
 'radial-gradient(circle at center, yellow 0%, #009966 50%, purple 100%)'
+```
+
+## Localization
+
+Use the `labels` prop to override any visible text string. All keys are optional — unspecified ones keep their default English values.
+
+| Key        | Default      | Description               |
+| :--------- | :----------: | :------------------------ |
+| `solid`    | `"Solid"`    | Solid tab label           |
+| `gradient` | `"Gradient"` | Gradient tab label        |
+| `hex`      | `"Hex"`      | Hex color input label     |
+| `alpha`    | `"Alpha"`    | Alpha/opacity input label |
+
+```tsx
+<ReactGPicker
+  value='#3a86ff'
+  gradient
+  solid
+  onChange={onChange}
+  labels={{
+    solid: 'Uni',
+    gradient: 'Dégradé',
+    hex: 'Hex',
+    alpha: 'Opacité'
+  }}
+/>
 ```
 
 ## FAQ

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -123,4 +123,31 @@ describe('Test Suites Color Picker', () => {
 
     expect(defaulPanel.length).toBe(12);
   });
+
+  it('Check labels props', () => {
+    const labels = {
+      solid: 'Uni',
+      gradient: 'Dégradé',
+      hex: 'Hex',
+      alpha: 'Opacité'
+    };
+    const withLabels = mount(
+      <ReactGPicker
+        {...props}
+        labels={labels}
+        gradient={true}
+        showAlpha={true}
+        showInputs={true}
+      />
+    );
+    const solidLabel = withLabels.find('.popup_tabs-header-label').at(0);
+    const gradientLabel = withLabels.find('.popup_tabs-header-label').at(1);
+    const hexLabel = withLabels.find('.input_rgba-hex .input_rgba-label');
+    const alphaLabel = withLabels.find('.input_rgba-alpha .input_rgba-label');
+
+    expect(solidLabel.text()).toBe(labels.solid);
+    expect(gradientLabel.text()).toBe(labels.gradient);
+    expect(hexLabel.text()).toBe(labels.hex);
+    expect(alphaLabel.text()).toBe(labels.alpha);
+  });
 });

--- a/src/components/Colorpicker/Gradient/index.tsx
+++ b/src/components/Colorpicker/Gradient/index.tsx
@@ -31,7 +31,8 @@ const Gradient: FC<IPropsComp> = ({
   showGradientPosition = true,
   allowAddGradientStops = true,
   colorBoardHeight = 120,
-  defaultColors
+  defaultColors,
+  labels = {}
 }) => {
   const parsedColors = useCallback(() => {
     return parseGradient(value);
@@ -154,6 +155,7 @@ const Gradient: FC<IPropsComp> = ({
             }))
           }
           onSubmitChange={onSubmitChange}
+          labels={labels}
         />
       )}
       <GradientPanel

--- a/src/components/Colorpicker/Solid/index.tsx
+++ b/src/components/Colorpicker/Solid/index.tsx
@@ -18,7 +18,8 @@ const ColorPickerSolid: FC<IPropsComp> = ({
   showAlpha = true,
   showInputs = true,
   colorBoardHeight = 120,
-  defaultColors
+  defaultColors,
+  labels = {}
 }) => {
   const node = useRef<HTMLDivElement | null>(null);
 
@@ -75,6 +76,7 @@ const ColorPickerSolid: FC<IPropsComp> = ({
           showAlpha={showAlpha}
           onChange={setColor}
           onSubmitChange={onChange}
+          labels={labels}
         />
       )}
       <DefaultColorsPanel

--- a/src/components/Colorpicker/index.tsx
+++ b/src/components/Colorpicker/index.tsx
@@ -37,7 +37,8 @@ const ColorPicker: FC<IPropsMain> = ({
   defaultColors = DEFAULT_COLORS,
   defaultActiveTab,
   onChangeTabs,
-  onChange = () => ({})
+  onChange = () => ({}),
+  labels = {}
 }) => {
   const [activeTab, setActiveTab] = useState<string>(
     defaultActiveTab || getIndexActiveTag(value)
@@ -66,13 +67,13 @@ const ColorPicker: FC<IPropsMain> = ({
             tabName='solid'
             onClick={() => onChangeTab('solid')}
           >
-            Solid
+            {labels.solid ?? 'Solid'}
           </PopupTabsHeaderLabel>
           <PopupTabsHeaderLabel
             tabName='gradient'
             onClick={() => onChangeTab('gradient')}
           >
-            Gradient
+            {labels.gradient ?? 'Gradient'}
           </PopupTabsHeaderLabel>
         </PopupTabsHeader>
         <PopupTabsBody>
@@ -87,6 +88,7 @@ const ColorPicker: FC<IPropsMain> = ({
               showAlpha={showAlpha}
               showInputs={showInputs}
               colorBoardHeight={colorBoardHeight}
+              labels={labels}
             />
           </PopupTabsBodyItem>
           <PopupTabsBodyItem tabName='gradient'>
@@ -106,6 +108,7 @@ const ColorPicker: FC<IPropsMain> = ({
               showGradientPosition={showGradientPosition}
               allowAddGradientStops={allowAddGradientStops}
               colorBoardHeight={colorBoardHeight}
+              labels={labels}
             />
           </PopupTabsBodyItem>
         </PopupTabsBody>
@@ -129,6 +132,7 @@ const ColorPicker: FC<IPropsMain> = ({
                 showAlpha={showAlpha}
                 showInputs={showInputs}
                 colorBoardHeight={colorBoardHeight}
+                labels={labels}
               />
             ) : (
               <Fragment />
@@ -150,6 +154,7 @@ const ColorPicker: FC<IPropsMain> = ({
                 showGradientPosition={showGradientPosition}
                 allowAddGradientStops={allowAddGradientStops}
                 colorBoardHeight={colorBoardHeight}
+                labels={labels}
               />
             ) : (
               <Fragment />

--- a/src/components/Colorpicker/types.ts
+++ b/src/components/Colorpicker/types.ts
@@ -1,5 +1,12 @@
 import { ReactText } from 'react';
 
+export interface ILabels {
+  solid?: string;
+  gradient?: string;
+  hex?: string;
+  alpha?: string;
+}
+
 export interface IPropsComp {
   value: string;
   format?: 'rgb' | 'hsl' | 'hex';
@@ -18,6 +25,7 @@ export interface IPropsComp {
   defaultActiveTab?: string | undefined;
   onChangeTabs?: (tab: string) => void;
   onChange: (value: string) => void;
+  labels?: ILabels;
 }
 
 export interface IPropsMain extends IPropsComp {

--- a/src/components/InputRgba/helpers.ts
+++ b/src/components/InputRgba/helpers.ts
@@ -1,4 +1,5 @@
 import { KeyboardEvent, ChangeEvent } from 'react';
+import { ILabels } from '../Colorpicker/types';
 
 interface IInput {
   alphaValue: number;
@@ -6,6 +7,7 @@ interface IInput {
   showAlpha?: boolean;
   onChangeAlpha: (value: string) => void;
   onChangeHex: (value: string) => void;
+  labels?: ILabels;
 }
 
 export const getAlphaValue = (value: string) => {
@@ -41,7 +43,7 @@ export const inputsData = (props: IInput) => {
     labelSymbol: true,
     idInput: `rgba-hex${Math.random() * 10000}`,
     valueInput: props.hexValue,
-    labelText: 'Hex',
+    labelText: props.labels?.hex ?? 'Hex',
     labelArea: 'hex',
     labelClass: 'input_rgba-label',
     onChangeInput: (e: ChangeEvent<HTMLInputElement>) =>
@@ -54,7 +56,7 @@ export const inputsData = (props: IInput) => {
     labelSymbol: false,
     idInput: `rgba-alpha${Math.random() * 10000}`,
     valueInput: props.alphaValue,
-    labelText: 'Alpha',
+    labelText: props.labels?.alpha ?? 'Alpha',
     labelArea: 'alpha',
     labelClass: 'input_rgba-label',
     onChangeInput: (e: ChangeEvent<HTMLInputElement>) =>

--- a/src/components/InputRgba/index.tsx
+++ b/src/components/InputRgba/index.tsx
@@ -3,6 +3,7 @@ import tinycolor from 'tinycolor2';
 import './_input_rgba.scss';
 
 import { checkFormat } from '../../utils';
+import { ILabels } from '../Colorpicker/types';
 import { getAlphaValue, inputsData, handlePressEnter } from './helpers';
 
 interface IChange {
@@ -17,6 +18,7 @@ type TProps = {
   showAlpha?: boolean;
   onChange: ({ hex, alpha }: IChange) => void;
   onSubmitChange?: (rgba: string) => void;
+  labels?: ILabels;
 };
 
 const InputRgba: FC<TProps> = ({
@@ -25,7 +27,8 @@ const InputRgba: FC<TProps> = ({
   format = 'rgb',
   showAlpha = true,
   onChange,
-  onSubmitChange
+  onSubmitChange,
+  labels = {}
 }) => {
   const [color, setColor] = useState({
     alpha,
@@ -86,7 +89,8 @@ const InputRgba: FC<TProps> = ({
     hexValue: color.hex.replace(/#/i, ''),
     onChangeAlpha,
     onChangeHex,
-    showAlpha
+    showAlpha,
+    labels
   };
 
   return (

--- a/stories/Locales.stories.tsx
+++ b/stories/Locales.stories.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import ReactGPicker from './ReactGPicker';
+import { IPropsMain } from '../src/components/Colorpicker/types';
+
+export default {
+  title: 'Example/Locales',
+  component: ReactGPicker
+} as Meta;
+
+const Template: Story<IPropsMain> = (args) => <ReactGPicker {...args} />;
+
+export const French = Template.bind({});
+French.args = {
+  labels: {
+    solid: 'Uni',
+    gradient: 'Dégradé',
+    hex: 'Hex',
+    alpha: 'Opacité'
+  },
+  gradient: true
+};
+
+export const Spanish = Template.bind({});
+Spanish.args = {
+  labels: {
+    solid: 'Sólido',
+    gradient: 'Degradado',
+    hex: 'Hex',
+    alpha: 'Opacidad'
+  },
+  gradient: true
+};
+
+export const Partial = Template.bind({});
+Partial.args = {
+  labels: {
+    solid: 'Uni',
+    gradient: 'Dégradé'
+  },
+  gradient: true
+};

--- a/stories/ReactGPicker.tsx
+++ b/stories/ReactGPicker.tsx
@@ -15,7 +15,8 @@ const ReactGPicker: FC<IPropsMain> = ({
   popupWidth,
   colorBoardHeight,
   defaultColors,
-  onChange
+  onChange,
+  labels
 }) => {
   const [color, setColor] = useState(value);
   const onChangeColor = (value: string) => setColor(value);
@@ -26,11 +27,7 @@ const ReactGPicker: FC<IPropsMain> = ({
 
   return (
     <div className='wrapper' style={{ background: color }}>
-      <span
-        role='textbox'
-        aria-multiline='true'
-        className='color-text'
-      >
+      <span role='textbox' aria-multiline='true' className='color-text'>
         {color}
       </span>
       <div className='centered'>
@@ -49,6 +46,7 @@ const ReactGPicker: FC<IPropsMain> = ({
             onChangeColor(value);
             onChange(value);
           }}
+          labels={labels}
         />
       </div>
     </div>


### PR DESCRIPTION
Add optional `labels` prop to support localization in the color picker.

- Introduced ILabels type and threaded `labels` through Colorpicker, Solid, Gradient and InputRgba components.
- Input labels (Hex/Alpha) now use provided values with English fallbacks.
- Updated Colorpicker tabs to render localized tab labels when provided.
- Added unit test to verify label rendering and Storybook stories (French/Spanish/Partial) demonstrating usage.
- Documented the `labels` prop and examples in README under a new Localization section.

This enables overriding visible text strings without changing component behavior; unspecified keys fall back to default English values.